### PR TITLE
LSP Integration

### DIFF
--- a/step-03-retrieval-approaches/lsp/Dockerfile
+++ b/step-03-retrieval-approaches/lsp/Dockerfile
@@ -1,0 +1,25 @@
+# docker build -t mam10eks/lsp:0.0.1 .
+FROM ubuntu:24.04
+
+RUN apt-get update \
+	&& apt-get install -y python3 python3-pip git curl build-essential \
+	&& apt-get clean
+
+# LSP is compiled from source at image build time and needs the Rust nightly
+# toolchain (the exact version is pinned by rust-toolchain.toml in the LSP repo).
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain none --profile minimal
+ENV PATH=/root/.cargo/bin:$PATH
+
+ADD requirements.txt /tmp/requirements.txt
+
+# On amd64 we target x86-64-v3 (AVX2, portable across modern x86 servers) instead
+# of target-cpu=native so the published image runs on any recent x86 host.
+RUN if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
+        export RUSTFLAGS="-C target-cpu=x86-64-v3 -C opt-level=3"; \
+    fi \
+    && pip3 install -r /tmp/requirements.txt --break-system-packages \
+    && rm -Rf /tmp/requirements.txt /root/.cargo/registry /root/.cargo/git \
+    && pip3 cache purge
+
+ADD build-and-search-lsp-index.py /index-and-retrieve.py
+RUN chmod +x /index-and-retrieve.py

--- a/step-03-retrieval-approaches/lsp/README.md
+++ b/step-03-retrieval-approaches/lsp/README.md
@@ -1,0 +1,51 @@
+# LSP
+
+[LSP](https://github.com/thefxperson/hierarchical_pruning) is a learned sparse retrieval engine written in Rust that
+extends BMP (SIGIR '24) and SP (SIGIR '25') with a hierarchical superblock index:
+document embeddings are quantized to 8-bit impacts and laid out in fixed-size blocks,
+and queries are processed by pruning (super)blocks whose upper-bound score cannot enter the top-k.
+
+The entrypoint indexes the document embeddings in memory and answers all queries in a single batched
+call into the Rust engine. Currently only `linux/amd64` is supported 
+
+Tunable knobs (defaults are rank-safe): 
+`--gamma` (guaranteed number of superblocks), 
+`--mu` (threshold overestimation),
+`--eta` (probabalistic safeness (and within-block threshold overestimation)),
+`--beta` (query pruning).
+Indexing parameters:
+`--bsize` (superblock,block sizes),
+`--compression` (block upper-bound storage: `simdbp`, `superblock` or `raw`),
+`--quant` (quantization of those upper bounds; they are stored as `impact >> quant`, so the
+default of `4` keeps them in 4 bits, which is what makes the SIMD-BP packing pay off, and `8`
+keeps the full 8-bit impact),
+`--compress-doc` (document index layout: `seismic`, `flatinv` or `bmp` — all three rank
+identically and differ only in memory footprint and block-scoring speed),
+`--threads` (parallel search).
+
+`--k` must be 10, 100 or 1000: LSP only keeps kth-score statistics at those depths.
+
+## Submission
+
+```
+tira-cli code-submission \
+    --path . \
+    --task lsr-benchmark \
+    --tira-vm-id reneuir-baselines \
+    --dataset tiny-example-20251002_0-training \
+    --command '/index-and-retrieve.py --dataset $inputDataset --embedding $embeddings --output $outputDir' \
+    --mount-directory '$embeddings=lsr-benchmark/lightning-ir/naver-splade-v3-doc' \
+    --dry-run
+```
+
+## Development
+
+This directory is [configured as DevContainer](https://code.visualstudio.com/docs/devcontainers/containers), i.e., you can open this directory with VS Code or some other DevContainer compatible IDE to work directly in the Docker container with all dependencies installed.
+
+If you want to run it locally, please install the dependencies via `pip3 install -r requirements.txt` (this compiles LSP from source and needs the Rust nightly toolchain via [rustup](https://rustup.rs/)).
+
+To make predictions on a dataset, run:
+
+```
+./build-and-search-lsp-index.py --dataset lsr-benchmark/clueweb09/en/trec-web-2009 --embedding naver/splade-v3 --output output-dir
+```

--- a/step-03-retrieval-approaches/lsp/README.md
+++ b/step-03-retrieval-approaches/lsp/README.md
@@ -8,6 +8,9 @@ and queries are processed by pruning (super)blocks whose upper-bound score canno
 The entrypoint indexes the document embeddings in memory and answers all queries in a single batched
 call into the Rust engine. Currently only `linux/amd64` is supported 
 
+Before indexing, documents are reordered with [GuideKP](https://github.com/pisa-engine/guidekp)
+(kmeans-guided recursive graph bisection), which is required for high quality retrieval results.
+
 Tunable knobs (defaults are rank-safe): 
 `--gamma` (guaranteed number of superblocks), 
 `--mu` (threshold overestimation),

--- a/step-03-retrieval-approaches/lsp/build-and-search-lsp-index.py
+++ b/step-03-retrieval-approaches/lsp/build-and-search-lsp-index.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+import gzip
+from shutil import rmtree
+
+import click
+import ir_datasets
+import lsr_benchmark
+from lsp import Indexer
+from lsr_benchmark.click import retrieve_command
+from tirex_tracker import ExportFormat, register_metadata, tracking
+from tqdm import tqdm
+
+
+@retrieve_command()
+@click.option("--beta", type=float, required=False, default=0.33, help="Query pruning factor (fraction of query terms kept).")
+@click.option("--gamma", type=int, required=False, default=250, help="Guaranteed number of superblocks to evaluate.")
+@click.option("--mu", type=float, required=False, default=0.0001, help="Threshold overestimation factor (1.0 = safe).")
+@click.option("--eta", type=float, required=False, default=1.0, help="Probabilistic safeness factor (1.0 = safe).")
+@click.option("--bsize", type=str, required=False, default="128,8", help="Comma-separated block sizes (superblock,block).")
+@click.option("--quant", type=int, required=False, default=4, help="Quantization of the block upper bounds: currently only 4 bits and 8 bits are supported.")
+@click.option("--compression", type=click.Choice(["raw", "superblock", "simdbp"]), required=False, default="simdbp", help="Compression of the block upper bounds.")
+@click.option("--compress-doc", type=click.Choice(["seismic", "flatinv", "bmp"]), required=False, default="seismic", help="Layout of the document index. All three rank identically; they differ in memory footprint and block-scoring speed.")
+def main(dataset, embedding, output, k, beta, gamma, mu, eta, bsize, quant, compression, compress_doc):
+    # LSP only stores kth-score statistics for these depths; any other k reads past
+    # the end of that vector and panics inside the Rust engine.
+    if k not in (10, 100, 1000):
+        raise click.BadParameter("LSP supports k of 10, 100 or 1000", param_hint="--k")
+    output.mkdir(parents=True, exist_ok=True)
+    lsr_benchmark.register_to_ir_datasets(dataset)
+    ir_dataset = ir_datasets.load(f"lsr-benchmark/{dataset}")
+    block_sizes = [int(b) for b in bsize.split(",")]
+
+    # the index layout is part of the tag: the variants rank identically but are
+    # exactly what this task measures the efficiency of
+    register_metadata({"actor": {"team": "reneuir-baselines"}, "tag": f"lsp-{embedding.replace('/', '-')}-{compression}-{compress_doc}-{quant}-{beta}-{gamma}-{mu}-{k}"})
+
+    # the values in the npz files are not guaranteed to be numeric (e.g., the query
+    # embeddings of some datasets store them as strings), hence the astype below
+    doc_embeddings = [
+        (doc_id, tokens.tolist(), values.astype("float32").tolist())
+        for doc_id, tokens, values in ir_dataset.doc_embeddings(model_name=embedding)
+    ]
+    # LSP quantizes document term weights to 8-bit impacts relative to the global maximum.
+    max_value = max((max(values) for _, _, values in doc_embeddings if values), default=1.0)
+
+    with tracking(export_file_path=output / "index-metadata.yml", export_format=ExportFormat.IR_METADATA):
+        indexer = Indexer(bsize=block_sizes, max_value=max_value, quant=quant, compress_range=compression, compress_doc=compress_doc)
+        for doc_id, tokens, values in tqdm(doc_embeddings, "create lsp index"):
+            indexer.add_document(doc_id, tokens, values)
+        searcher = indexer.build()
+
+    query_embeddings = list(ir_dataset.query_embeddings(model_name=embedding))
+
+    rmtree(output / ".tirex-tracker")
+
+    results = []
+
+    with tracking(export_file_path=output / "retrieval-metadata.yml", export_format=ExportFormat.IR_METADATA):
+        for _, tokens, values in query_embeddings:
+            results.append(searcher.search(
+                tokens.tolist(), values.astype("float32").tolist(),
+                k=k, beta=beta, gamma=gamma, mu=mu, eta=eta,
+            ))
+
+    rmtree(output / ".tirex-tracker")
+    with gzip.open(output / "run.txt.gz", "wt") as f:
+        for (query_id, _, _), (docnos, scores) in zip(query_embeddings, results):
+            for rank, (docno, score) in enumerate(zip(docnos, scores), start=1):
+                f.write(f"{query_id} Q0 {docno} {rank} {score} lsp\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/step-03-retrieval-approaches/lsp/build-and-search-lsp-index.py
+++ b/step-03-retrieval-approaches/lsp/build-and-search-lsp-index.py
@@ -45,20 +45,16 @@ def main(dataset, embedding, output, k, beta, gamma, mu, eta, bsize, quant, comp
     # LSP quantizes document term weights to 8-bit impacts relative to the global maximum.
     max_value = max((max(values) for _, _, values in doc_embeddings if values), default=1.0)
 
-    # Reorder documents with GuideKP before indexing. The LSP index lays documents out in
-    # blocks in insertion order, so permuting the list here is the document reordering.
-    # GuideKP normally operates on CIFF; reorder_documents builds its forward index directly
-    # from these sparse vectors and returns the new order (order[new_pos] = original index).
-    # It is given the same max_value as the index so its weight->tf quantization matches.
-    order = reorder_documents(
-        [doc_id for doc_id, _, _ in doc_embeddings],
-        [tokens for _, tokens, _ in doc_embeddings],
-        [values for _, _, values in doc_embeddings],
-        max_value=max_value,
-    )
-    doc_embeddings = [doc_embeddings[i] for i in order]
-
     with tracking(export_file_path=output / "index-metadata.yml", export_format=ExportFormat.IR_METADATA):
+        # Reorder documents with GuideKP before indexing.
+        order = reorder_documents(
+            [doc_id for doc_id, _, _ in doc_embeddings],
+            [tokens for _, tokens, _ in doc_embeddings],
+            [values for _, _, values in doc_embeddings],
+            max_value=max_value,
+        )
+        doc_embeddings = [doc_embeddings[i] for i in order]
+
         indexer = Indexer(bsize=block_sizes, max_value=max_value, quant=quant, compress_range=compression, compress_doc=compress_doc)
         for doc_id, tokens, values in tqdm(doc_embeddings, "create lsp index"):
             indexer.add_document(doc_id, tokens, values)

--- a/step-03-retrieval-approaches/lsp/build-and-search-lsp-index.py
+++ b/step-03-retrieval-approaches/lsp/build-and-search-lsp-index.py
@@ -5,6 +5,7 @@ from shutil import rmtree
 import click
 import ir_datasets
 import lsr_benchmark
+from guidekp import reorder_documents
 from lsp import Indexer
 from lsr_benchmark.click import retrieve_command
 from tirex_tracker import ExportFormat, register_metadata, tracking
@@ -31,7 +32,7 @@ def main(dataset, embedding, output, k, beta, gamma, mu, eta, bsize, quant, comp
     block_sizes = [int(b) for b in bsize.split(",")]
 
     # the index layout is part of the tag: the variants rank identically but are
-    # exactly what this task measures the efficiency of
+    # exactly what this task measures the efficiency of. the document ordering
     register_metadata({"actor": {"team": "reneuir-baselines"}, "tag": f"lsp-{embedding.replace('/', '-')}-{compression}-{compress_doc}-{quant}-{beta}-{gamma}-{mu}-{k}"})
 
     # the values in the npz files are not guaranteed to be numeric (e.g., the query
@@ -40,8 +41,22 @@ def main(dataset, embedding, output, k, beta, gamma, mu, eta, bsize, quant, comp
         (doc_id, tokens.tolist(), values.astype("float32").tolist())
         for doc_id, tokens, values in ir_dataset.doc_embeddings(model_name=embedding)
     ]
+
     # LSP quantizes document term weights to 8-bit impacts relative to the global maximum.
     max_value = max((max(values) for _, _, values in doc_embeddings if values), default=1.0)
+
+    # Reorder documents with GuideKP before indexing. The LSP index lays documents out in
+    # blocks in insertion order, so permuting the list here is the document reordering.
+    # GuideKP normally operates on CIFF; reorder_documents builds its forward index directly
+    # from these sparse vectors and returns the new order (order[new_pos] = original index).
+    # It is given the same max_value as the index so its weight->tf quantization matches.
+    order = reorder_documents(
+        [doc_id for doc_id, _, _ in doc_embeddings],
+        [tokens for _, tokens, _ in doc_embeddings],
+        [values for _, _, values in doc_embeddings],
+        max_value=max_value,
+    )
+    doc_embeddings = [doc_embeddings[i] for i in order]
 
     with tracking(export_file_path=output / "index-metadata.yml", export_format=ExportFormat.IR_METADATA):
         indexer = Indexer(bsize=block_sizes, max_value=max_value, quant=quant, compress_range=compression, compress_doc=compress_doc)

--- a/step-03-retrieval-approaches/lsp/requirements.txt
+++ b/step-03-retrieval-approaches/lsp/requirements.txt
@@ -1,0 +1,6 @@
+git+https://github.com/reneuir/lsr-benchmark.git
+tirex-tracker>=0.2.16
+tira>=0.0.180
+click
+tqdm
+git+https://github.com/thefxperson/hierarchical_pruning#subdirectory=python

--- a/step-03-retrieval-approaches/lsp/requirements.txt
+++ b/step-03-retrieval-approaches/lsp/requirements.txt
@@ -4,3 +4,4 @@ tira>=0.0.180
 click
 tqdm
 git+https://github.com/thefxperson/hierarchical_pruning#subdirectory=python
+git+https://github.com/pisa-engine/guidekp#subdirectory=python


### PR DESCRIPTION
This PR adds support for the LSP retriever (SIGIR '26) in step-03-retrieval-approaches. I've tested these changes locally, just opening here to get feedback on any needed changes before merging. Also, I'm at SIGIR all week so if you find me we can discuss offline.

Questions:
* Are there any guidelines on how the retrievers should be configured by default? i.e. should they default to safe search, or approximate? Is it acceptable to tweak the defaults parameters based on dataset size/top-k size?

Limitations:
* no ARM support, only x86
* I'm still looking into adding BP reordering/clustering as a pre-step. This is currently just a rust project and I might need to put in a PR for python bindings upstream. The current PR still works, but will have degraded quality.
